### PR TITLE
Fix Spark indexer hashing to group like events together

### DIFF
--- a/src/main/scala/io/druid/indexer/spark/SparkDruidIndexer.scala
+++ b/src/main/scala/io/druid/indexer/spark/SparkDruidIndexer.scala
@@ -56,6 +56,7 @@ import org.apache.spark.{Logging, Partitioner, SparkContext}
 import org.joda.time.{DateTime, Interval}
 
 import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
 import scala.util.control.NonFatal
 
 object SparkDruidIndexer extends Logging {
@@ -146,10 +147,16 @@ object SparkDruidIndexer extends Logging {
       )
 
     logInfo("Starting uniqes")
-    var uniquesEvents = baseData
-    if (dataSchema.getDelegate.getParser.getParseSpec.getDimensionsSpec.hasCustomDimensions) {
+    val optionalDims : Option[Set[String]] = if( dataSchema.getDelegate.getParser.getParseSpec.getDimensionsSpec.hasCustomDimensions) {
       val parseSpec = dataSchema.getDelegate.getParser.getParseSpec
-      val dims: Set[String] = (Set[String]() ++ parseSpec.getDimensionsSpec.getDimensions) -- parseSpec.getDimensionsSpec.getDimensionExclusions
+      Option((Set[String]() ++ parseSpec.getDimensionsSpec.getDimensions) -- parseSpec.getDimensionsSpec.getDimensionExclusions)
+    } else {
+      None
+    }
+
+    var uniquesEvents = baseData
+    if (optionalDims.isDefined) {
+      val dims = optionalDims.get
       uniquesEvents = baseData.mapValues(_.filterKeys(dims.contains))
     }
 
@@ -189,7 +196,8 @@ object SparkDruidIndexer extends Logging {
       .partitionBy(
         new DateBucketAndHashPartitioner(
           dataSchema.getDelegate.getGranularitySpec.getSegmentGranularity,
-          hashToPartitionMap
+          hashToPartitionMap,
+          optionalDims
         )
       )
       .mapPartitionsWithIndex(
@@ -609,32 +617,46 @@ class DateBucketPartitioner(gran: Granularity, intervals: Iterable[Interval]) ex
   }
 }
 
-class DateBucketAndHashPartitioner(gran: Granularity, partMap: Map[(Long, Long), Int])
+class DateBucketAndHashPartitioner(gran: Granularity, partMap: Map[(Long, Long), Int], optionalDims : Option[Set[String]] = None)
   extends Partitioner {
   val maxTimePerBucket = partMap.groupBy(_._1._1).map(e => e._1 -> e._2.size)
+  val dims = optionalDims.orNull
+
 
   override def numPartitions: Int = partMap.size
 
   override def getPartition(key: Any): Int = key match {
     case (k: Long, v: AnyRef) =>
+      val map : Map[String, AnyRef] = v match {
+        case mm: util.Map[String, AnyRef] =>
+          mm.asScala.toMap
+        case mm: Map[String, AnyRef] =>
+          mm
+        case x =>
+          throw new IAE(s"Unknown value type ${x.getClass} : [$x]")
+      }
       val dateBucket = gran.truncate(new DateTime(k)).getMillis
       val modSize = maxTimePerBucket.get(dateBucket.toLong)
       if (modSize.isEmpty) {
         // Lazy ISE creation
         throw new ISE(s"bad date bucket [${dateBucket.toLong}]. " +
-          "available: ${maxTimePerBucket.keySet}")
+          s"available: ${maxTimePerBucket.keySet}")
       }
       val m = modSize.get
       if (m <= 0) {
         throw new ISE(s"Illegal mod [$m]")
       }
-      val hash = Math.abs(v.hashCode().toLong) % m.toLong
+      val hash = if(dims != null) {
+        Math.abs(map.filterKeys(dims.contains).hashCode().toLong) % m.toLong
+      } else {
+        Math.abs(map.hashCode().toLong) % m.toLong
+      }
       val partOpt = partMap.get((dateBucket.toLong, hash.toLong))
       if (partOpt.isEmpty) {
         throw new ISE(s"bad hash and bucket combo: ($dateBucket, $hash)")
       }
       partOpt.get
-    case x => throw new IAE(s"Unknown type [$x]")
+    case x => throw new IAE(s"Unknown type ${x.getClass} : [$x]")
   }
 }
 

--- a/src/test/scala/io/druid/indexer/spark/TestSparkDruidIndexer.scala
+++ b/src/test/scala/io/druid/indexer/spark/TestSparkDruidIndexer.scala
@@ -21,6 +21,7 @@ package io.druid.indexer.spark
 
 import java.io.{Closeable, File}
 import java.nio.file.Files
+import java.util
 
 import com.google.common.collect.ImmutableList
 import com.google.common.io.Closer
@@ -29,7 +30,7 @@ import com.metamx.common.{CompressionUtils, Granularity, IAE}
 import io.druid.common.utils.JodaUtils
 import io.druid.data.input.impl.{DimensionsSpec, JSONParseSpec, TimestampSpec}
 import io.druid.query.aggregation.LongSumAggregatorFactory
-import io.druid.segment._
+import io.druid.segment.QueryableIndexIndexableAdapter
 import org.apache.commons.io.FileUtils
 import org.apache.spark.{SparkConf, SparkContext}
 import org.joda.time.{DateTime, Interval}
@@ -38,8 +39,7 @@ import org.scalatest._
 import scala.collection.JavaConverters._
 
 
-class TestSparkDruidIndexer extends FlatSpec with Matchers
-{
+class TestSparkDruidIndexer extends FlatSpec with Matchers {
 
   import TestScalaBatchIndexTask._
 
@@ -52,8 +52,7 @@ class TestSparkDruidIndexer extends FlatSpec with Matchers
     val outDir = Files.createTempDirectory("segments").toFile
     (outDir.mkdirs() || outDir.exists()) && outDir.isDirectory should be(true)
     closer.register(
-      new Closeable()
-      {
+      new Closeable() {
         override def close(): Unit = FileUtils.deleteDirectory(outDir)
       }
     )
@@ -74,8 +73,7 @@ class TestSparkDruidIndexer extends FlatSpec with Matchers
 
       val sc = new SparkContext(conf)
       closer.register(
-        new Closeable
-        {
+        new Closeable {
           override def close(): Unit = sc.stop()
         }
       )
@@ -176,8 +174,7 @@ class TestSparkDruidIndexer extends FlatSpec with Matchers
     val outDir = Files.createTempDirectory("segments").toFile
     (outDir.mkdirs() || outDir.exists()) && outDir.isDirectory should be(true)
     closer.register(
-      new Closeable()
-      {
+      new Closeable() {
         override def close(): Unit = FileUtils.deleteDirectory(outDir)
       }
     )
@@ -198,8 +195,7 @@ class TestSparkDruidIndexer extends FlatSpec with Matchers
 
       val sc = new SparkContext(conf)
       closer.register(
-        new Closeable
-        {
+        new Closeable {
           override def close(): Unit = sc.stop()
         }
       )
@@ -330,11 +326,35 @@ class TestSparkDruidIndexer extends FlatSpec with Matchers
     partitioner.getPartition(makeEvent(intervals.last.getEnd.minus(10L))) should equal(1)
     partitioner.getPartition(makeEvent(intervals.last.getEnd.minus(10L), "something else")) should equal(2)
     partitioner.getPartition(makeEvent(intervals.last.getEnd.minus(10L), "anotherHash3")) should equal(2)
-    partitioner.getPartition(makeEvent(intervals.last.getEnd.minus(10L), "anotherHash")) should equal(1)
+    partitioner.getPartition(makeEvent(intervals.last.getEnd.minus(10L), "anotherHash1")) should equal(1)
   }
 
-  def makeEvent(d: DateTime, v: String = "dim11"): (Long, Seq[(String, List[String])]) = {
-    (d.getMillis, List(("dim1", List(v))))
+  "The DateBucketAndHashPartitioner workflow" should "properly partition multiple date ranges and buckets when dim is specified" in {
+    val intervals = SparkBatchIndexTask.mapToSegmentIntervals(Seq(Interval.parse("1992/1994")), Granularity.YEAR)
+    val map = Map(new DateTime("1992").getMillis -> 100L, new DateTime("1993").getMillis -> 200L)
+    val m = SparkDruidIndexer.getSizedPartitionMap(map, 150)
+    val partitioner = new DateBucketAndHashPartitioner(Granularity.YEAR, m, Option(Set("dim1")))
+    partitioner.getPartition(makeEvent(intervals.head.getStart)) should equal(0)
+    partitioner.getPartition(makeEvent(intervals.last.getEnd.minus(10L))) should equal(1)
+    partitioner.getPartition(makeEvent(intervals.last.getEnd.minus(10L), "something else")) should equal(2)
+    partitioner.getPartition(makeEvent(intervals.last.getEnd.minus(10L), "anotherHash3")) should equal(2)
+    partitioner.getPartition(makeEvent(intervals.last.getEnd.minus(10L), "anotherHash1")) should equal(1)
+  }
+
+  "The DateBucketAndHashPartitioner workflow" should "properly group multiple events together" in {
+    val intervals = SparkBatchIndexTask.mapToSegmentIntervals(Seq(Interval.parse("1992/1994")), Granularity.YEAR)
+    val map = Map(new DateTime("1992").getMillis -> 100L, new DateTime("1993").getMillis -> 200L)
+    val m = SparkDruidIndexer.getSizedPartitionMap(map, 150)
+    val partitioner = new DateBucketAndHashPartitioner(Granularity.YEAR, m, Option(Set[String]()))
+    partitioner.getPartition(makeEvent(intervals.head.getStart)) should equal(0)
+    partitioner.getPartition(makeEvent(intervals.last.getEnd.minus(10L))) should equal(1)
+    partitioner.getPartition(makeEvent(intervals.last.getEnd.minus(10L), "something else")) should equal(1)
+    partitioner.getPartition(makeEvent(intervals.last.getEnd.minus(10L), "anotherHash3")) should equal(1)
+    partitioner.getPartition(makeEvent(intervals.last.getEnd.minus(10L), "anotherHash1")) should equal(1)
+  }
+
+  def makeEvent(d: DateTime, v: String = "dim11"): (Long, Map[String, List[String]]) = {
+    d.getMillis -> Map("dim1" -> List(v))
   }
 
   "getSizedPartitionMap" should "partition data correctly for single items" in {
@@ -384,16 +404,15 @@ class TestSparkDruidIndexer extends FlatSpec with Matchers
     val partitioner = new
         DateBucketAndHashPartitioner(Granularity.YEAR, Map[(Long, Long), Int]((0L, 0L) -> 1, (0L, 0L) -> 2))
     partitioner.getPartition(
-      (100000L, new Object() {
+      100000L -> new util.HashMap[String, AnyRef]() {
         override def hashCode(): Int = {
           Integer.MIN_VALUE
         }
-      })
+      }
     ) should be(2)
   }
 }
 
-object StaticTestSparkDruidIndexer
-{
+object StaticTestSparkDruidIndexer {
   val log = new Logger(classOf[TestSparkDruidIndexer])
 }


### PR DESCRIPTION
Otherwise like dimensions can be spread all over the place