### PR TITLE
Default maxRowsInMemory and rowFlushBoundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ The json keys accepted by the spark batch indexer are described below
 |`paths`              |List of strings |Yes               |N/A              |A list of hadoop-readable input files. The values are joined with a `,` and used as a `SparkContext.textFile`|
 |`dataSchema`         |DataSchema      |Yes               |N/A              |The data schema to use|
 |`intervals`          |List of strings |Yes               |N/A              |A list of ISO intervals to be indexed. ALL data for these intervals MUST be present in `paths`|
-|`maxRowsInMemory`    |positive integer|No                |`80000`          |Maximum number of rows to store in memory before an intermediate flush to disk|
+|`maxRowsInMemory`    |positive integer|No                |`75000`          |Maximum number of rows to store in memory before an intermediate flush to disk|
 |`targetPartitionSize`|positive integer|No                |`5000000`        |The target number of rows per partition per segment granularity|
 |`master`             |String          |No                |`master[1]`      |The spark master URI|
 |`properties`         |Map             |No                |none             | A map of string key/value pairs to inject into the SparkContext properties overriding any prior set values|

--- a/src/main/scala/io/druid/indexer/spark/SparkBatchIndexTask.scala
+++ b/src/main/scala/io/druid/indexer/spark/SparkBatchIndexTask.scala
@@ -239,7 +239,7 @@ class SparkBatchIndexTask(
 
 object SparkBatchIndexTask
 {
-  private val DEFAULT_ROW_FLUSH_BOUNDARY   : Int    = 80000
+  private val DEFAULT_ROW_FLUSH_BOUNDARY   : Int    = 75000
   private val DEFAULT_TARGET_PARTITION_SIZE: Long   = 5000000L
   private val CHILD_PROPERTY_PREFIX        : String = "druid.indexer.fork.property."
   val log                   = new Logger(SparkBatchIndexTask.getClass)


### PR DESCRIPTION
In https://github.com/druid-io/druid/pull/2457 it was suggested that
the default for maxRowsInMemory and rowFlushBoundary would be set to
75000 across druid source and documentation. This commit brings the
values in this repository in sync with that.