### PR TITLE
BACKEND-614 Spark batch `buildV9Directly` support

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ The json keys accepted by the spark batch indexer are described below
 |`indexSpec`          |InputSpec       |No                |concise, lz4, lz4|The InputSpec containing the various compressions to be used|
 |`context`            |Map             |No                |none             |The task context|
 |`hadoopDependencyCoordinates`|List of strings|No|`null` (use default set by druid config)|The spark dependency coordinates to load in the ClassLoader when launching the task|
+|`buildV9Directly`    |Boolean         |No                |False             |Build v9 index directly instead of building v8 index and converting it to v9 format.|
 
 ### Deploying this project
 

--- a/src/main/scala/io/druid/indexer/spark/SparkBatchIndexTask.scala
+++ b/src/main/scala/io/druid/indexer/spark/SparkBatchIndexTask.scala
@@ -78,7 +78,9 @@ class SparkBatchIndexTask(
   @JsonProperty("classpathPrefix")
   classpathPrefix: String = null,
   @JsonProperty("hadoopDependencyCoordinates")
-  hadoopDependencyCoordinates: util.List[String] = null
+  hadoopDependencyCoordinates: util.List[String] = null,
+  @JsonProperty("buildV9Directly")
+  buildV9Directly: Boolean = false
 ) extends HadoopTask(
   if (id == null) {
     AbstractTask
@@ -195,7 +197,8 @@ class SparkBatchIndexTask(
       Objects.equals(getMaster, other.getMaster) &&
       Objects.equals(getContext, other.getContext) &&
       Objects.equals(getIndexSpec, other.getIndexSpec) &&
-      Objects.equals(getClasspathPrefix, other.getClasspathPrefix)
+      Objects.equals(getClasspathPrefix, other.getClasspathPrefix) &&
+      Objects.equals(getBuildV9Directly, other.getBuildV9Directly)
   }
 
   // This is kind of weird to get a lock that's not based on granularityIntervals but its how the hadoop indexer did it
@@ -242,7 +245,12 @@ class SparkBatchIndexTask(
   @JsonProperty("hadoopDependencyCoordinates")
   def getHadoopCoordinates = hadoopDependencyCoordinates
 
-  override def toString = s"SparkBatchIndexTask($getType, $getId, $getDataSchema, $getIntervals, $getDataFiles, $getTargetPartitionSize, $getRowFlushBoundary, $getProperties, $getMaster, $getContext, $getIndexSpec, $getClasspathPrefix)"
+  @JsonProperty("buildV9Directly")
+  def getBuildV9Directly = buildV9Directly
+
+  override def toString = s"SparkBatchIndexTask($getType, $getId, $getDataSchema, $getIntervals, $getDataFiles, " +
+    s"$getTargetPartitionSize, $getRowFlushBoundary, $getProperties, $getMaster, $getContext, $getIndexSpec, " +
+    s"$getClasspathPrefix, $getBuildV9Directly)"
 }
 
 object SparkBatchIndexTask
@@ -432,6 +440,7 @@ object SparkBatchIndexTask
         task.getRowFlushBoundary,
         outputPath,
         task.getIndexSpec,
+        task.getBuildV9Directly,
         sc
       ).map(_.withVersion(version))
       log.info("Found segments `%s`", util.Arrays.deepToString(dataSegments.toArray))

--- a/src/test/scala/io/druid/indexer/spark/TestScalaBatchIndexTask.scala
+++ b/src/test/scala/io/druid/indexer/spark/TestScalaBatchIndexTask.scala
@@ -181,7 +181,8 @@ object TestScalaBatchIndexTask
     context: Map[String, Object] = Map(),
     indexSpec: IndexSpec = indexSpec,
     classpathPrefix: String = classpathPrefix,
-    hadoopDependencyCoordinates: java.util.List[String] = hadoopDependencyCoordinates
+    hadoopDependencyCoordinates: java.util.List[String] = hadoopDependencyCoordinates,
+    buildV9Directly: Boolean = buildV9Directly
   ): SparkBatchIndexTask = new SparkBatchIndexTask(
     id,
     dataSchema,
@@ -194,7 +195,8 @@ object TestScalaBatchIndexTask
     context,
     indexSpec,
     classpathPrefix,
-    hadoopDependencyCoordinates
+    hadoopDependencyCoordinates,
+    buildV9Directly
   )
 }
 
@@ -220,6 +222,7 @@ class TestScalaBatchIndexTask extends FlatSpec with Matchers
     taskPre.targetPartitionSize_ should equal(taskPost.targetPartitionSize_)
     taskPre.getHadoopDependencyCoordinates should equal(taskPost.getHadoopDependencyCoordinates)
     taskPre.getHadoopDependencyCoordinates should equal(hadoopDependencyCoordinates)
+    taskPre.getBuildV9Directly should equal(taskPost.getBuildV9Directly)
   }
 
   it should "properly deserialize" in {
@@ -288,5 +291,7 @@ class TestScalaBatchIndexTask extends FlatSpec with Matchers
     task1 should not equal buildSparkBatchIndexTask(context = Map[String, Object]("test" -> "oops"))
 
     task1 should not equal buildSparkBatchIndexTask(classpathPrefix = "someOther.jar")
+
+    task1 should not equal buildSparkBatchIndexTask(buildV9Directly = false)
   }
 }

--- a/src/test/scala/io/druid/indexer/spark/TestScalaBatchIndexTask.scala
+++ b/src/test/scala/io/druid/indexer/spark/TestScalaBatchIndexTask.scala
@@ -198,6 +198,18 @@ object TestScalaBatchIndexTask
     hadoopDependencyCoordinates,
     buildV9Directly
   )
+
+  def buildSparkBatchIndexTaskWithoutV9(
+    id: String = taskId,
+    dataSchema: DataSchema = dataSchema,
+    interval: Interval = interval,
+    dataFiles: Seq[String] = dataFiles
+  ): SparkBatchIndexTask = new SparkBatchIndexTask(
+    id,
+    dataSchema,
+    Seq(interval),
+    dataFiles
+  )
 }
 
 class TestScalaBatchIndexTask extends FlatSpec with Matchers
@@ -238,6 +250,7 @@ class TestScalaBatchIndexTask extends FlatSpec with Matchers
       ===(taskPre.getDataSchema.getParser.getParseSpec)
     task.asInstanceOf[SparkBatchIndexTask].getHadoopDependencyCoordinates.asScala should
       ===(Seq("org.apache.spark:spark-core_2.10:1.6.1-mmx0"))
+    task.asInstanceOf[SparkBatchIndexTask].getBuildV9Directly should equal(false)
   }
 
   it should "be equal for equal tasks" in {
@@ -293,5 +306,11 @@ class TestScalaBatchIndexTask extends FlatSpec with Matchers
     task1 should not equal buildSparkBatchIndexTask(classpathPrefix = "someOther.jar")
 
     task1 should not equal buildSparkBatchIndexTask(buildV9Directly = false)
+  }
+
+  it should "default buildV9Directly to false if not specified" in {
+
+    val taskWithoutV9 = buildSparkBatchIndexTaskWithoutV9()
+    taskWithoutV9.getBuildV9Directly should equal(false)
   }
 }

--- a/src/test/scala/io/druid/indexer/spark/TestScalaBatchIndexTask.scala
+++ b/src/test/scala/io/druid/indexer/spark/TestScalaBatchIndexTask.scala
@@ -152,6 +152,7 @@ object TestScalaBatchIndexTask
   val indexSpec                   = new IndexSpec()
   val classpathPrefix             = "somePrefix.jar"
   val hadoopDependencyCoordinates = Collections.singletonList("some:coordinate:version")
+  val buildV9Directly             = true
 
   def buildDataSchema(
     dataSource: String = dataSource,

--- a/src/test/scala/io/druid/indexer/spark/TestSparkDruidIndexer.scala
+++ b/src/test/scala/io/druid/indexer/spark/TestSparkDruidIndexer.scala
@@ -87,6 +87,7 @@ class TestSparkDruidIndexer extends FlatSpec with Matchers
         rowsPerFlush,
         outDir.toString,
         indexSpec,
+        buildV9Directly,
         sc
       )
       loadResults.length should be(7)
@@ -231,6 +232,7 @@ class TestSparkDruidIndexer extends FlatSpec with Matchers
         rowsPerFlush,
         outDir.toString,
         indexSpec,
+        buildV9Directly,
         sc
       )
       loadResults.length should be(1)


### PR DESCRIPTION
 - Added support for `buildV9Directly`
 - Noted the property in docs
 - Modified pre existing tests to account for the same