### PR TITLE
remove serializeOutIndex

### DIFF
--- a/src/main/scala/io/druid/indexer/spark/SparkDruidIndexer.scala
+++ b/src/main/scala/io/druid/indexer/spark/SparkDruidIndexer.scala
@@ -361,21 +361,7 @@ object SparkDruidIndexer {
               -1,
               -1
             )
-            val dataSegment = JobHelper.serializeOutIndex(
-              dataSegmentTemplate,
-              hadoopConf,
-              new Progressable {
-                override def progress(): Unit = logDebug("Progress")
-              },
-              new TaskAttemptID(new org.apache.hadoop.mapred.TaskID(), index),
-              file,
-              JobHelper.makeSegmentOutputPath(
-                outPath,
-                hadoopFs,
-                dataSegmentTemplate
-              )
-            )
-            val finalDataSegment = pusher.push(file, dataSegment)
+            val finalDataSegment = pusher.push(file, dataSegmentTemplate)
             logInfo(s"Finished pushing $finalDataSegment")
             Seq(new SerializedJson[DataSegment](finalDataSegment)).iterator
           }


### PR DESCRIPTION
With current implementation, `pusher.push()` always overwrites an `index.zip` file generated and uploaded by `serializeOutIndex()`. Since `serializeOutIndex()` deletes an existing `index.zip` file whereas `pusher.push()` simply overwrites, removing `serializeOutIndex()` will yield the same result and eliminate the potential problem that's caused by Spark scheduler's race condition between multiple attempts.