### PR TITLE
add emitter for internal metrics and accumulator

### DIFF
--- a/src/main/scala/io/druid/indexer/spark/SparkBatchIndexTask.scala
+++ b/src/main/scala/io/druid/indexer/spark/SparkBatchIndexTask.scala
@@ -41,14 +41,6 @@ import io.druid.segment.IndexSpec
 import io.druid.segment.indexing.DataSchema
 import io.druid.timeline.DataSegment
 import org.apache.spark.{SparkConf, SparkContext}
-import java.io.Closeable
-import java.io.File
-import java.io.IOException
-import java.io.PrintWriter
-import java.nio.file.Files
-import java.util
-import java.util.Objects
-import java.util.Properties
 import org.apache.spark.scheduler.{AccumulableInfo, SparkListener, SparkListenerStageCompleted}
 import org.joda.time.Interval
 

--- a/src/main/scala/io/druid/indexer/spark/SparkDruidIndexer.scala
+++ b/src/main/scala/io/druid/indexer/spark/SparkDruidIndexer.scala
@@ -29,13 +29,14 @@ import com.fasterxml.jackson.core.`type`.TypeReference
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.google.common.io.Closer
 import com.google.inject.{Binder, Injector, Key, Module}
+import com.metamx.common.lifecycle.Lifecycle
 import com.metamx.common.logger.Logger
 import com.metamx.common.{Granularity, IAE, ISE}
 import io.druid.data.input.impl._
 import io.druid.data.input.{MapBasedInputRow, ProtoBufInputRowParser}
 import io.druid.guice.annotations.{Json, Self}
 import io.druid.guice.{GuiceInjectors, JsonConfigProvider}
-import io.druid.indexer.{HadoopyStringInputRowParser, JobHelper}
+import io.druid.indexer.HadoopyStringInputRowParser
 import io.druid.initialization.Initialization
 import io.druid.query.aggregation.AggregatorFactory
 import io.druid.segment._
@@ -49,8 +50,6 @@ import io.druid.timeline.partition.{HashBasedNumberedShardSpec, NoneShardSpec, S
 import org.apache.commons.io.FileUtils
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
-import org.apache.hadoop.mapreduce.TaskAttemptID
-import org.apache.hadoop.util.Progressable
 import org.apache.spark.rdd.RDD
 import org.apache.spark.storage.StorageLevel
 import org.apache.spark.{Partitioner, SparkContext}
@@ -458,6 +457,16 @@ object SerializedJsonStatic {
     catch {
       case NonFatal(e) =>
         LOG.error(e, "Error getting object mapper instance")
+        throw e
+    }
+  }
+
+  lazy val lifecycle: Lifecycle = {
+    try {
+      injector.getInstance(classOf[Lifecycle])
+    } catch {
+      case NonFatal(e) =>
+        LOG.error(e, "Error getting life cycle instance")
         throw e
     }
   }

--- a/src/test/scala/io/druid/indexer/spark/TestScalaBatchIndexTask.scala
+++ b/src/test/scala/io/druid/indexer/spark/TestScalaBatchIndexTask.scala
@@ -21,12 +21,10 @@ package io.druid.indexer.spark
 
 import com.fasterxml.jackson.core.`type`.TypeReference
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.google.common.io.Closer
 import com.google.inject.Binder
 import com.google.inject.Module
 import com.google.inject.name.Names
 import com.metamx.common.Granularity
-import com.metamx.common.lifecycle.Lifecycle
 import io.druid.data.input.impl._
 import io.druid.granularity.QueryGranularities
 import io.druid.granularity.QueryGranularity
@@ -155,7 +153,6 @@ object TestScalaBatchIndexTask
   val classpathPrefix             = "somePrefix.jar"
   val hadoopDependencyCoordinates = Collections.singletonList("some:coordinate:version")
   val buildV9Directly             = true
-  val lifeCycle                   = new Lifecycle
 
   def buildDataSchema(
     dataSource: String = dataSource,

--- a/src/test/scala/io/druid/indexer/spark/TestScalaBatchIndexTask.scala
+++ b/src/test/scala/io/druid/indexer/spark/TestScalaBatchIndexTask.scala
@@ -25,6 +25,8 @@ import com.google.inject.Binder
 import com.google.inject.Module
 import com.google.inject.name.Names
 import com.metamx.common.Granularity
+import com.metamx.common.lifecycle.Lifecycle
+import com.metamx.emitter.core.{HttpPostEmitter, NoopEmitter}
 import io.druid.data.input.impl._
 import io.druid.granularity.QueryGranularities
 import io.druid.granularity.QueryGranularity
@@ -153,6 +155,7 @@ object TestScalaBatchIndexTask
   val classpathPrefix             = "somePrefix.jar"
   val hadoopDependencyCoordinates = Collections.singletonList("some:coordinate:version")
   val buildV9Directly             = true
+  val lifeCycle                   = new Lifecycle
 
   def buildDataSchema(
     dataSource: String = dataSource,
@@ -312,5 +315,29 @@ class TestScalaBatchIndexTask extends FlatSpec with Matchers
 
     val taskWithoutV9 = buildSparkBatchIndexTaskWithoutV9()
     taskWithoutV9.getBuildV9Directly should equal(false)
+  }
+
+  it should "provide default noop emitter" in {
+    val emitter = SparkBatchIndexTask.createEmitter(properties, lifeCycle)
+
+    emitter.getClass should equal(classOf[NoopEmitter])
+  }
+
+  it should "provide http emitter" in {
+    val props = new Properties()
+    props.putAll(
+      Map(
+        ("user.timezone", "UTC"),
+        ("file.encoding", "UTF-8"),
+        ("java.util.logging.manager", "org.apache.logging.log4j.jul.LogManager"),
+        ("org.jboss.logging.provider", "log4j2"),
+        ("druid.processing.columnCache.sizeBytes", "1000000000"),
+        ("com.metamx.emitter.http", "true"),
+        ("com.metamx.emitter.http.url", "https://dummy.url")
+      )
+    )
+    val emitter = SparkBatchIndexTask.createEmitter(props, lifeCycle)
+
+    emitter.getClass should equal(classOf[HttpPostEmitter])
   }
 }

--- a/src/test/scala/io/druid/indexer/spark/TestScalaBatchIndexTask.scala
+++ b/src/test/scala/io/druid/indexer/spark/TestScalaBatchIndexTask.scala
@@ -21,12 +21,12 @@ package io.druid.indexer.spark
 
 import com.fasterxml.jackson.core.`type`.TypeReference
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.google.common.io.Closer
 import com.google.inject.Binder
 import com.google.inject.Module
 import com.google.inject.name.Names
 import com.metamx.common.Granularity
 import com.metamx.common.lifecycle.Lifecycle
-import com.metamx.emitter.core.{HttpPostEmitter, NoopEmitter}
 import io.druid.data.input.impl._
 import io.druid.granularity.QueryGranularities
 import io.druid.granularity.QueryGranularity
@@ -315,29 +315,5 @@ class TestScalaBatchIndexTask extends FlatSpec with Matchers
 
     val taskWithoutV9 = buildSparkBatchIndexTaskWithoutV9()
     taskWithoutV9.getBuildV9Directly should equal(false)
-  }
-
-  it should "provide default noop emitter" in {
-    val emitter = SparkBatchIndexTask.createEmitter(properties, lifeCycle)
-
-    emitter.getClass should equal(classOf[NoopEmitter])
-  }
-
-  it should "provide http emitter" in {
-    val props = new Properties()
-    props.putAll(
-      Map(
-        ("user.timezone", "UTC"),
-        ("file.encoding", "UTF-8"),
-        ("java.util.logging.manager", "org.apache.logging.log4j.jul.LogManager"),
-        ("org.jboss.logging.provider", "log4j2"),
-        ("druid.processing.columnCache.sizeBytes", "1000000000"),
-        ("com.metamx.emitter.http", "true"),
-        ("com.metamx.emitter.http.url", "https://dummy.url")
-      )
-    )
-    val emitter = SparkBatchIndexTask.createEmitter(props, lifeCycle)
-
-    emitter.getClass should equal(classOf[HttpPostEmitter])
   }
 }

--- a/src/test/scala/io/druid/indexer/spark/TestSparkDruidIndexer.scala
+++ b/src/test/scala/io/druid/indexer/spark/TestSparkDruidIndexer.scala
@@ -19,27 +19,24 @@
 
 package io.druid.indexer.spark
 
+import java.io.{Closeable, File}
+import java.nio.file.Files
+import java.util
 import com.google.common.collect.ImmutableList
 import com.google.common.io.Closer
 import com.metamx.common.logger.Logger
-import com.metamx.common.CompressionUtils
-import com.metamx.common.IAE
-import _root_.io.druid.common.utils.JodaUtils
-import _root_.io.druid.data.input.impl.DimensionsSpec
-import _root_.io.druid.data.input.impl.JSONParseSpec
-import _root_.io.druid.data.input.impl.StringDimensionSchema
-import _root_.io.druid.data.input.impl.TimestampSpec
-import _root_.io.druid.query.aggregation.LongSumAggregatorFactory
-import _root_.io.druid.segment.QueryableIndexIndexableAdapter
-import java.io.Closeable
-import java.io.File
-import java.nio.file.Files
-import java.util
+import com.metamx.common.{CompressionUtils, IAE}
+import com.metamx.emitter.core.HttpPostEmitter
+import com.metamx.emitter.core.NoopEmitter
+import io.druid.common.utils.JodaUtils
+import io.druid.data.input.impl.{DimensionsSpec, JSONParseSpec, StringDimensionSchema, TimestampSpec}
+import io.druid.java.util.common.granularity.Granularities
+import io.druid.query.aggregation.LongSumAggregatorFactory
+import io.druid.segment.QueryableIndexIndexableAdapter
+import java.util.Properties
 import org.apache.commons.io.FileUtils
-import org.apache.spark.SparkConf
-import org.apache.spark.SparkContext
-import org.joda.time.DateTime
-import org.joda.time.Interval
+import org.apache.spark.{SparkConf, SparkContext}
+import org.joda.time.{DateTime, Interval}
 import org.scalatest._
 import scala.collection.JavaConverters._
 
@@ -423,6 +420,7 @@ class TestSparkDruidIndexer extends FlatSpec with Matchers
     m.size should equal(1)
     m.get((0L, 0L)) should equal(Some(0L))
   }
+
   it should "properly index skipped intervals" in {
     val map = Map(0L -> 100L, 1L -> 0L, 2L -> 100L)
     val m = SparkDruidIndexer.getSizedPartitionMap(map, 1000)
@@ -430,6 +428,7 @@ class TestSparkDruidIndexer extends FlatSpec with Matchers
     m.get((0L, 0L)) should equal(Some(0L))
     m.get((2L, 0L)) should equal(Some(1L))
   }
+
   "DateBucketAndHashPartitioner" should "handle min value hash" in {
     val partitioner = new
         DateBucketAndHashPartitioner(Granularities.YEAR, Map[(Long, Long), Int]((0L, 0L) -> 1, (0L, 0L) -> 2))

--- a/src/test/scala/io/druid/indexer/spark/TestSparkDruidIndexer.scala
+++ b/src/test/scala/io/druid/indexer/spark/TestSparkDruidIndexer.scala
@@ -19,24 +19,28 @@
 
 package io.druid.indexer.spark
 
-import java.io.{Closeable, File}
-import java.nio.file.Files
-import java.util
-
 import com.google.common.collect.ImmutableList
 import com.google.common.io.Closer
 import com.metamx.common.logger.Logger
-import com.metamx.common.{CompressionUtils, IAE}
-import io.druid.common.utils.JodaUtils
-import io.druid.data.input.impl.{DimensionsSpec, JSONParseSpec, StringDimensionSchema, TimestampSpec}
-import io.druid.java.util.common.granularity.Granularities
-import io.druid.query.aggregation.LongSumAggregatorFactory
-import io.druid.segment.QueryableIndexIndexableAdapter
+import com.metamx.common.CompressionUtils
+import com.metamx.common.IAE
+import _root_.io.druid.common.utils.JodaUtils
+import _root_.io.druid.data.input.impl.DimensionsSpec
+import _root_.io.druid.data.input.impl.JSONParseSpec
+import _root_.io.druid.data.input.impl.StringDimensionSchema
+import _root_.io.druid.data.input.impl.TimestampSpec
+import _root_.io.druid.query.aggregation.LongSumAggregatorFactory
+import _root_.io.druid.segment.QueryableIndexIndexableAdapter
+import java.io.Closeable
+import java.io.File
+import java.nio.file.Files
+import java.util
 import org.apache.commons.io.FileUtils
-import org.apache.spark.{SparkConf, SparkContext}
-import org.joda.time.{DateTime, Interval}
+import org.apache.spark.SparkConf
+import org.apache.spark.SparkContext
+import org.joda.time.DateTime
+import org.joda.time.Interval
 import org.scalatest._
-
 import scala.collection.JavaConverters._
 
 


### PR DESCRIPTION
From Spark 2.0, Spark application's internal metrics such as `executorRuntime` are logged as an accumulator per stage. This PR enables those metrics, as well as custom accumulators, to be emitted to the server. 

The default emitter is `NoopEmitter`, so the behavior of the indexing task should stay the same even if the configuration is not changed after the update to this version.