### PR TITLE
Refactor metrics

### DIFF
--- a/src/main/scala/io/druid/indexer/spark/SparkBatchIndexTask.scala
+++ b/src/main/scala/io/druid/indexer/spark/SparkBatchIndexTask.scala
@@ -19,29 +19,36 @@
 
 package io.druid.indexer.spark
 
-import java.io.{Closeable, File, IOException, PrintWriter}
-import java.nio.file.Files
-import java.util
-import java.util.{Objects, Properties}
-import com.fasterxml.jackson.annotation.{JsonCreator, JsonProperty}
-import com.google.common.base.{Preconditions, Strings}
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.google.common.base.Preconditions
+import com.google.common.base.Strings
 import com.google.common.collect.Iterables
 import com.google.common.io.Closer
 import com.metamx.common.logger.Logger
-import com.metamx.emitter.service.{ServiceEmitter, ServiceMetricEvent}
 import io.druid.common.utils.JodaUtils
 import io.druid.data.input.impl.ParseSpec
-import io.druid.indexing.common.actions.{LockTryAcquireAction, TaskActionClient}
-import io.druid.indexing.common.task.{AbstractTask, HadoopTask}
-import io.druid.indexing.common.{TaskStatus, TaskToolbox}
+import io.druid.indexing.common.actions.LockTryAcquireAction
+import io.druid.indexing.common.actions.TaskActionClient
+import io.druid.indexing.common.task.AbstractTask
+import io.druid.indexing.common.task.HadoopTask
+import io.druid.indexing.common.TaskStatus
+import io.druid.indexing.common.TaskToolbox
 import io.druid.java.util.common.granularity._
 import io.druid.query.aggregation.AggregatorFactory
 import io.druid.segment.IndexSpec
 import io.druid.segment.indexing.DataSchema
 import io.druid.timeline.DataSegment
-import org.apache.spark.scheduler.SparkListenerApplicationEnd
-import org.apache.spark.{SparkConf, SparkContext}
-import org.apache.spark.scheduler.{AccumulableInfo, SparkListener, SparkListenerStageCompleted}
+import java.io.Closeable
+import java.io.File
+impgitort java.io.IOException
+import java.io.PrintWriter
+import java.nio.file.Files
+import java.util
+import java.util.Objects
+import java.util.Properties
+import org.apache.spark.SparkConf
+import org.apache.spark.SparkContext
 import org.joda.time.Interval
 import scala.collection.JavaConversions._
 
@@ -400,43 +407,6 @@ object SparkBatchIndexTask
           sc.hadoopConfiguration.set(y, System.getProperty(x), "Druid Forking Property")
         }
       )
-
-      log.info("Initializing emitter for metrics")
-
-      lifecycle.start()
-
-      sc.addSparkListener(new SparkListener() {
-        // Emit metrics at the end of each stage
-        override def onStageCompleted(stageCompleted: SparkListenerStageCompleted): Unit = {
-          val dimensions = Map(
-            "taskId" -> task.getId,
-            "stageId" -> stageCompleted.stageInfo.stageId.toString,
-            "interval" -> SerializedJsonStatic.mapper.writeValueAsString(task.getIntervals)
-          )
-
-          val accumulatedInfo = stageCompleted.stageInfo.accumulables.toMap.flatMap {
-            case (_, AccumulableInfo(_, Some(name), _, Some(value: Long), _, _, _)) =>
-              Some(name -> value)
-
-            case _ =>
-              None
-          }
-
-          accumulatedInfo foreach { case (aggName, value) =>
-            log.debug("emitting metric: %s".format(aggName))
-            val eventBuilder = ServiceMetricEvent.builder()
-            dimensions foreach { case (n, v) => eventBuilder.setDimension(n, v)}
-            emitter.emit(
-              eventBuilder.build(aggName, value)
-            )
-          }
-        }
-
-        // Closes lifecycle when sc.stop() is called
-        override def onApplicationEnd(applicationEnd: SparkListenerApplicationEnd): Unit = {
-          lifecycle.stop()
-        }
-      })
 
       // Should be set by HadoopTask for job jars
       // Hadoop tasks use io.druid.indexer.JobHelper::setupClasspath to replicate their jars.

--- a/src/main/scala/io/druid/indexer/spark/SparkBatchIndexTask.scala
+++ b/src/main/scala/io/druid/indexer/spark/SparkBatchIndexTask.scala
@@ -19,37 +19,29 @@
 
 package io.druid.indexer.spark
 
-import com.fasterxml.jackson.annotation.JsonCreator
-import com.fasterxml.jackson.annotation.JsonProperty
-import com.google.common.base.Preconditions
-import com.google.common.base.Strings
+import java.io.{Closeable, File, IOException, PrintWriter}
+import java.nio.file.Files
+import java.util
+import java.util.{Objects, Properties}
+
+import com.fasterxml.jackson.annotation.{JsonCreator, JsonProperty}
+import com.google.common.base.{Preconditions, Strings}
 import com.google.common.collect.Iterables
 import com.google.common.io.Closer
 import com.metamx.common.logger.Logger
 import io.druid.common.utils.JodaUtils
 import io.druid.data.input.impl.ParseSpec
-import io.druid.indexing.common.actions.LockTryAcquireAction
-import io.druid.indexing.common.actions.TaskActionClient
-import io.druid.indexing.common.task.AbstractTask
-import io.druid.indexing.common.task.HadoopTask
-import io.druid.indexing.common.TaskStatus
-import io.druid.indexing.common.TaskToolbox
+import io.druid.indexing.common.{TaskStatus, TaskToolbox}
+import io.druid.indexing.common.actions.{LockTryAcquireAction, TaskActionClient}
+import io.druid.indexing.common.task.{AbstractTask, HadoopTask}
 import io.druid.java.util.common.granularity._
 import io.druid.query.aggregation.AggregatorFactory
 import io.druid.segment.IndexSpec
 import io.druid.segment.indexing.DataSchema
 import io.druid.timeline.DataSegment
-import java.io.Closeable
-import java.io.File
-impgitort java.io.IOException
-import java.io.PrintWriter
-import java.nio.file.Files
-import java.util
-import java.util.Objects
-import java.util.Properties
-import org.apache.spark.SparkConf
-import org.apache.spark.SparkContext
+import org.apache.spark.{SparkConf, SparkContext}
 import org.joda.time.Interval
+
 import scala.collection.JavaConversions._
 
 @JsonCreator

--- a/src/main/scala/io/druid/indexer/spark/SparkDruidIndexer.scala
+++ b/src/main/scala/io/druid/indexer/spark/SparkDruidIndexer.scala
@@ -79,10 +79,9 @@ object SparkDruidIndexer {
     val dataSource = dataSchema.getDelegate.getDataSource
     val lifecycle      = SerializedJsonStatic.lifecycle
     val emitter        = SerializedJsonStatic.emitter
+
     logInfo("Initializing emitter for metrics")
-
     lifecycle.start()
-
     sc.addSparkListener(new SparkListener() {
       // Emit metrics at the end of each stage
       override def onStageCompleted(stageCompleted: SparkListenerStageCompleted): Unit = {
@@ -92,15 +91,12 @@ object SparkDruidIndexer {
           "stageId" -> stageCompleted.stageInfo.stageId.toString,
           "intervals" -> ingestIntervals.mkString("[",",","]")
         )
-
         val accumulatedInfo = stageCompleted.stageInfo.accumulables.toMap.flatMap {
           case (_, AccumulableInfo(_, Some(name), _, Some(value: Long), _, _, _)) =>
             Some(name -> value)
-
           case _ =>
             None
         }
-
         accumulatedInfo foreach { case (aggName, value) =>
           logDebug("emitting metric: %s".format(aggName))
           val eventBuilder = ServiceMetricEvent.builder()

--- a/src/main/scala/io/druid/indexer/spark/SparkDruidIndexer.scala
+++ b/src/main/scala/io/druid/indexer/spark/SparkDruidIndexer.scala
@@ -19,46 +19,61 @@
 
 package io.druid.indexer.spark
 
-import java.io._
-import java.nio.file.Files
-import java.util
-
-import com.esotericsoftware.kryo.io.{Input, Output}
-import com.esotericsoftware.kryo.{Kryo, KryoSerializable}
+import com.esotericsoftware.kryo.io.Input
+import com.esotericsoftware.kryo.io.Output
+import com.esotericsoftware.kryo.Kryo
+import com.esotericsoftware.kryo.KryoSerializable
 import com.fasterxml.jackson.core.`type`.TypeReference
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.google.common.io.Closer
 import com.google.inject.name.Names
-import com.google.inject.{Binder, Injector, Key, Module}
+import com.google.inject.Binder
+import com.google.inject.Injector
+import com.google.inject.Key
+import com.google.inject.Module
 import com.metamx.common.lifecycle.Lifecycle
 import com.metamx.common.logger.Logger
-import com.metamx.common.{IAE, ISE}
-import io.druid.data.input.MapBasedInputRow
+import com.metamx.common.IAE
+import com.metamx.common.ISE
 import com.metamx.emitter.service.ServiceEmitter
-import io.druid.data.input.impl._
-import io.druid.guice._
-import io.druid.guice.annotations.{Json, Self}
-import io.druid.indexer.HadoopyStringInputRowParser
-import io.druid.guice.{GuiceInjectors, JsonConfigProvider}
-import io.druid.indexer.HadoopyStringInputRowParser
-import io.druid.initialization.Initialization
-import io.druid.java.util.common.granularity.Granularity
-import io.druid.query.aggregation.AggregatorFactory
-import io.druid.segment._
-import io.druid.segment.column.ColumnConfig
-import io.druid.segment.incremental.{IncrementalIndex, IncrementalIndexSchema}
-import io.druid.segment.indexing.DataSchema
-import io.druid.segment.loading.DataSegmentPusher
-import io.druid.server.DruidNode
-import io.druid.timeline.DataSegment
-import io.druid.timeline.partition.{HashBasedNumberedShardSpec, NoneShardSpec, ShardSpec}
+import com.metamx.emitter.service.ServiceMetricEvent
+import _root_.io.druid.data.input.MapBasedInputRow
+import _root_.io.druid.data.input.impl._
+import _root_.io.druid.guice.annotations.Json
+import _root_.io.druid.guice.annotations.Self
+import _root_.io.druid.guice.GuiceInjectors
+import _root_.io.druid.guice.JsonConfigProvider
+import _root_.io.druid.indexer.HadoopyStringInputRowParser
+import _root_.io.druid.initialization.Initialization
+import _root_.io.druid.java.util.common.granularity.Granularity
+import _root_.io.druid.query.aggregation.AggregatorFactory
+import _root_.io.druid.segment._
+import _root_.io.druid.segment.column.ColumnConfig
+import _root_.io.druid.segment.incremental.IncrementalIndex
+import _root_.io.druid.segment.incremental.IncrementalIndexSchema
+import _root_.io.druid.segment.indexing.DataSchema
+import _root_.io.druid.segment.loading.DataSegmentPusher
+import _root_.io.druid.server.DruidNode
+import _root_.io.druid.timeline.DataSegment
+import _root_.io.druid.timeline.partition.HashBasedNumberedShardSpec
+import _root_.io.druid.timeline.partition.NoneShardSpec
+import _root_.io.druid.timeline.partition.ShardSpec
+import java.io._
+import java.nio.file.Files
+import java.util
 import org.apache.commons.io.FileUtils
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 import org.apache.spark.rdd.RDD
+import org.apache.spark.scheduler.AccumulableInfo
+import org.apache.spark.scheduler.SparkListener
+import org.apache.spark.scheduler.SparkListenerApplicationEnd
+import org.apache.spark.scheduler.SparkListenerStageCompleted
 import org.apache.spark.storage.StorageLevel
-import org.apache.spark.{Partitioner, SparkContext}
-import org.joda.time.{DateTime, Interval}
+import org.apache.spark.Partitioner
+import org.apache.spark.SparkContext
+import org.joda.time.DateTime
+import org.joda.time.Interval
 import scala.collection.JavaConversions._
 import scala.collection.JavaConverters._
 import scala.util.control.NonFatal
@@ -77,6 +92,45 @@ object SparkDruidIndexer {
                 sc: SparkContext
               ): Seq[DataSegment] = {
     val dataSource = dataSchema.getDelegate.getDataSource
+    val lifecycle      = SerializedJsonStatic.lifecycle
+    val emitter        = SerializedJsonStatic.emitter
+    logInfo("Initializing emitter for metrics")
+
+    lifecycle.start()
+
+    sc.addSparkListener(new SparkListener() {
+      // Emit metrics at the end of each stage
+      override def onStageCompleted(stageCompleted: SparkListenerStageCompleted): Unit = {
+        val dimensions = Map(
+          "appId" -> sc.applicationId,
+          "dataSource" -> dataSource,
+          "stageId" -> stageCompleted.stageInfo.stageId.toString,
+          "intervals" -> ingestIntervals.mkString("[",",","]")
+        )
+
+        val accumulatedInfo = stageCompleted.stageInfo.accumulables.toMap.flatMap {
+          case (_, AccumulableInfo(_, Some(name), _, Some(value: Long), _, _, _)) =>
+            Some(name -> value)
+
+          case _ =>
+            None
+        }
+
+        accumulatedInfo foreach { case (aggName, value) =>
+          logDebug("emitting metric: %s".format(aggName))
+          val eventBuilder = ServiceMetricEvent.builder()
+          dimensions foreach { case (n, v) => eventBuilder.setDimension(n, v)}
+          emitter.emit(
+            eventBuilder.build(aggName, value)
+          )
+        }
+      }
+      // Closes lifecycle when sc.stop() is called
+      override def onApplicationEnd(applicationEnd: SparkListenerApplicationEnd): Unit = {
+        lifecycle.stop()
+      }
+    })
+
     logInfo(s"Launching Spark task with jar version [${getClass.getPackage.getImplementationVersion}]")
     val dataSegmentVersion = DateTime.now().toString
     val hadoopConfig = new SerializedHadoopConfig(sc.hadoopConfiguration)


### PR DESCRIPTION
This moves metrics emission stuff out of `SparkBatchIndexTask` in order to avoid object mapping issue.